### PR TITLE
adds env-file and context for xs variables

### DIFF
--- a/component/cargo/Cargo.lock
+++ b/component/cargo/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "serde_yaml",
  "termcolor",
  "wind",
  "xc",

--- a/component/cargo/Cargo.lock
+++ b/component/cargo/Cargo.lock
@@ -666,6 +666,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "xr-parse-macro"
+version = "0.0.1"
+dependencies = [
+ "xr-parse",
+]
+
+[[package]]
 name = "xr-token"
 version = "0.0.1"
 

--- a/component/cargo/Cargo.toml
+++ b/component/cargo/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     './xr',
     './xr-dyn',
     './xr-parse',
+    './xr-parse-macro',
     './xr-token',
     './xs',
 ]
@@ -18,6 +19,9 @@ path = './xr-dyn'
 
 [patch.crates-io.xr-parse]
 path = './xr-parse'
+
+[patch.crates-io.xr-parse-macro]
+path = './xr-parse-macro'
 
 [patch.crates-io.xr-token]
 path = './xr-token'

--- a/component/cargo/Cargo.yaml
+++ b/component/cargo/Cargo.yaml
@@ -12,6 +12,7 @@ module:
       - ron
       - serde
       - serde_json
+      - serde_yaml
       - termcolor
       - wind
       - xerr

--- a/component/cargo/xs/Cargo.toml
+++ b/component/cargo/xs/Cargo.toml
@@ -20,6 +20,9 @@ optional = true
 [dependencies.serde_json]
 version = '1.0'
 
+[dependencies.serde_yaml]
+version = '0.8'
+
 [dependencies.termcolor]
 version = '1.1.2'
 

--- a/component/cargo/xs/src/ast.rs
+++ b/component/cargo/xs/src/ast.rs
@@ -48,20 +48,6 @@ pub enum Expr<'d> {
     List(Vec<Expr<'d>>),
 }
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-pub struct EnvMapValue {
-    pub description: Option<String>,
-    pub value: String,
-}
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(untagged)]
-pub enum EnvValue {
-    Str(String),
-    Map(EnvMapValue),
-}
-
-pub type EnvFile = HashMap<String, HashMap<String, EnvValue>>;
-
 #[derive(
     Debug, Clone, serde::Deserialize, serde::Serialize, wind::EnumDefault,
 )]
@@ -90,7 +76,5 @@ pub enum Io<'d> {
     Tty,
     Source(&'d str),
 }
-
-use std::collections::HashMap;
 
 use super::*;

--- a/component/cargo/xs/src/ast.rs
+++ b/component/cargo/xs/src/ast.rs
@@ -48,6 +48,20 @@ pub enum Expr<'d> {
     List(Vec<Expr<'d>>),
 }
 
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct EnvMapValue {
+    pub description: Option<String>,
+    pub value: String,
+}
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+pub enum EnvValue {
+    Str(String),
+    Map(EnvMapValue),
+}
+
+pub type EnvFile = HashMap<String, HashMap<String, EnvValue>>;
+
 #[derive(
     Debug, Clone, serde::Deserialize, serde::Serialize, wind::EnumDefault,
 )]
@@ -76,5 +90,7 @@ pub enum Io<'d> {
     Tty,
     Source(&'d str),
 }
+
+use std::collections::HashMap;
 
 use super::*;

--- a/component/cargo/xs/src/cli.rs
+++ b/component/cargo/xs/src/cli.rs
@@ -33,11 +33,8 @@ where
                 let env_file_path =
                     te!(env_file_path, "Missing argument to --env-file")
                         .as_ref();
-                let env_file = std::fs::File::open(env_file_path)?;
-                match serde_yaml::from_reader::<_, EnvFile>(&env_file) {
-                    Ok(envs) => opts.envs = envs,
-                    Err(err) => println!("{:?}", err),
-                }
+                let env_file = fs::File::open(env_file_path)?;
+                opts.envs = te!(serde_yaml::from_reader::<_, EnvFile>(&env_file), "Error loading yaml");
             }
             Some("--env-context") => {
                 let env_context = i.next();

--- a/component/cargo/xs/src/error.rs
+++ b/component/cargo/xs/src/error.rs
@@ -5,6 +5,7 @@ xError! {
     Utf8 = std::str::Utf8Error
     Utf8_ = std::string::FromUtf8Error
     Json = json::Error
+    Yaml = yaml::Error
     Xc = xc::Error
     Var = std::env::VarError
 }

--- a/component/cargo/xs/src/main.rs
+++ b/component/cargo/xs/src/main.rs
@@ -1,5 +1,3 @@
-use crate::ast::EnvValue;
-
 fn main() {
     pretty_env_logger::init();
 
@@ -14,8 +12,8 @@ fn main() {
         if let Some(ctx) = opts.envs.get(opts.env_ctx) {
             for (key, value) in ctx.into_iter() {
                 opts.named_args.entry(key).or_insert(match value {
-                    EnvValue::Str(str) => str,
-                    EnvValue::Map(map) => &map.value,
+                    cli::EnvValue::Str(str) => str,
+                    cli::EnvValue::Map(map) => &map.value,
                 });
             }
         }
@@ -85,17 +83,33 @@ mod output;
 use {
     clear::clearing,
     engine::Engine,
-    error::{err, te, xerr, Error, Result},
+    error::{
+        err,
+        te,
+        xerr,
+        Error,
+        Result,
+    },
     input::Input,
     serde_json as json,
     serde_yaml as yaml,
     std::{
-        borrow::{Borrow, BorrowMut, Cow},
+        borrow::{
+            Borrow,
+            BorrowMut,
+            Cow,
+        },
         collections::{
-            btree_map::{BTreeMap as Map, Entry},
+            btree_map::{
+                BTreeMap as Map,
+                Entry,
+            },
             VecDeque as Deq,
         },
-        convert::{TryFrom, TryInto},
+        convert::{
+            TryFrom,
+            TryInto,
+        },
         env,
         fmt,
         fs,

--- a/component/cargo/xs/src/main.rs
+++ b/component/cargo/xs/src/main.rs
@@ -88,6 +88,7 @@ use {
     error::{err, te, xerr, Error, Result},
     input::Input,
     serde_json as json,
+    serde_yaml as yaml,
     std::{
         borrow::{Borrow, BorrowMut, Cow},
         collections::{


### PR DESCRIPTION
Adds context-aware yaml-based env-file to xs.

Default context is set to "default".  Env file can be provided after `--env-file` flag. If default context is not the preferred context, it can be provided after `--env-context` flag. 

⚠️  Variables provided from CLI (with -ah) have always higher priority over env-file provided variables if any conflict occurs.

Sample env file:
```yaml
default:
  dr: '127.0.0.1'
  target: 'acceptance'
  some_key: 'asdasdsad'

acceptance:
  dr:
    description: 'Docker Registry ipv4 address'
    value: '10.0.1.128'
  target: 'production'
  some_key: 'asdasdsad'
```
lets name this yaml as `deployment.env.yaml`. This file contains two contexts: "default" and "acceptance". Values of the context variables can be either of type String or Object with an optional description and value of type String.

And we have a simple script to test, which we name as `test.ron`
```ron
Script([
  Exec(cmd: "echo", args: [(var: "dr")], output: Display),
  Exec(cmd: "echo", args: [(var: "some_key")], output: Display),
  Exec(cmd: "echo", args: [(var: "target")], output: Display)
])
```

normally we could run this script with:
```bash
xs -f test.ron -ah some_key "somesecretekey" -ah target "acceptance" -ah dr "127.0.0.1"
```

with this addition:
```bash
xs -f trial.ron --env-file deployment.env.yaml --env-context "acceptance"
```

or if you want to use the default context:
```bash
xs -f trial.ron --env-file deployment.env.yaml
```